### PR TITLE
fix: Add IPX-Clear and IPX-Q to valid resins

### DIFF
--- a/npxpy/nodes/project.py
+++ b/npxpy/nodes/project.py
@@ -103,14 +103,16 @@ class Project(Node):
     @resin.setter
     def resin(self, value: str):
         valid_resins = {
-            "IP-PDMS",
-            "IPX-S",
+            "IP-Dip",
+            "IP-Dip2",
             "IP-L",
             "IP-n162",
-            "IP-Dip2",
-            "IP-Dip",
+            "IP-PDMS",
             "IP-S",
             "IP-Visio",
+            "IPX-Clear",
+            "IPX-Q",
+            "IPX-S",
             "*",
         }
         if value not in valid_resins:

--- a/npxpy/preset.py
+++ b/npxpy/preset.py
@@ -116,14 +116,16 @@ class Preset:
     @valid_resins.setter
     def valid_resins(self, value):
         valid_resins_set = {
-            "IP-PDMS",
-            "IPX-S",
+            "IP-Dip",
+            "IP-Dip2",
             "IP-L",
             "IP-n162",
-            "IP-Dip2",
-            "IP-Dip",
+            "IP-PDMS",
             "IP-S",
             "IP-Visio",
+            "IPX-Clear",
+            "IPX-Q",
+            "IPX-S"
             "*",
         }
         if not set(value).issubset(valid_resins_set):


### PR DESCRIPTION
I also reordered the set to match the dropdown in nanoPrintX (sorted alphabetically).