### PR TITLE
fix: Fix 10x objective

### DIFF
--- a/npxpy/nodes/project.py
+++ b/npxpy/nodes/project.py
@@ -85,7 +85,7 @@ class Project(Node):
     @objective.setter
     def objective(self, value: str):
         valid_objectives = {
-            "10x",
+            "10xW",
             "25x",
             "63x",
             "*",

--- a/npxpy/preset.py
+++ b/npxpy/preset.py
@@ -104,7 +104,12 @@ class Preset:
 
     @valid_objectives.setter
     def valid_objectives(self, value):
-        valid_objectives_set = {"25x", "63x", "*"}
+        valid_objectives_set = {
+            "10xW",
+            "25x",
+            "63x",
+            "*"
+        }
         if not set(value).issubset(valid_objectives_set):
             raise ValueError(f"Invalid valid_objectives: {value}")
         self._valid_objectives = value


### PR DESCRIPTION
For some reason, the objective ID is `10xW`.

Maybe it would be better to use `10x` in npxpy, and only use `10xW` when exporting? Not sure what you'd prefer :)